### PR TITLE
Adds events

### DIFF
--- a/contracts/ERC20NonTransferableDividendsOwned.sol
+++ b/contracts/ERC20NonTransferableDividendsOwned.sol
@@ -15,6 +15,9 @@ contract ERC20NonTransferableDividendsOwned is ERC20NonTransferableDividends, Ow
   address public immutable token;
   bytes32 public participationMerkleRoot;
 
+  event CollectedFor(uint256 amount, address collector, address to, bytes32[] proof);
+
+
   enum ParticipationType{ INACTIVE, YES }
 
   modifier participationNeeded {
@@ -60,6 +63,8 @@ contract ERC20NonTransferableDividendsOwned is ERC20NonTransferableDividends, Ow
     require(MerkleProof.verify(proof, participationMerkleRoot, leaf), "collectForWithParticipation: Invalid merkle proof");
     uint256 amount = _prepareCollect(account);
     token.safeTransfer(account, amount);
+
+    emit CollectedFor(amount, msg.sender, account, proof);
   }
 
   function collectWithParticipation(bytes32[] calldata proof) external {

--- a/contracts/ERC20NonTransferableDividendsOwned.sol
+++ b/contracts/ERC20NonTransferableDividendsOwned.sol
@@ -15,7 +15,7 @@ contract ERC20NonTransferableDividendsOwned is ERC20NonTransferableDividends, Ow
   address public immutable token;
   bytes32 public participationMerkleRoot;
 
-  event CollectedFor(uint256 amount, address collector, address to, bytes32[] proof);
+  event CollectedFor(uint256 amount, address indexed collector, address indexed to, bytes32[] proof);
 
 
   enum ParticipationType{ INACTIVE, YES }

--- a/contracts/SharesTimeLock.sol
+++ b/contracts/SharesTimeLock.sol
@@ -71,10 +71,10 @@ contract SharesTimeLock is Ownable() {
   ];
 
   event MinLockAmountChanged(uint256 newLockAmount);
-  event Deposited(uint256 amount, uint32 lockDuration, address owner);
-  event Withdrawn(uint256 amount, address owner);
-  event Ejected(uint256 amount, address owner);
-  event BoostedToMax(uint256 amount, address owner);
+  event Deposited(uint256 amount, uint32 lockDuration, address indexed owner);
+  event Withdrawn(uint256 amount, address indexed owner);
+  event Ejected(uint256 amount, address indexed owner);
+  event BoostedToMax(uint256 amount, address indexed owner);
 
   struct Lock {
     uint256 amount;

--- a/contracts/SharesTimeLock.sol
+++ b/contracts/SharesTimeLock.sol
@@ -73,6 +73,8 @@ contract SharesTimeLock is Ownable() {
   event MinLockAmountChanged(uint256 newLockAmount);
   event Deposited(uint256 amount, uint32 lockDuration, address owner);
   event Withdrawn(uint256 amount, address owner);
+  event Ejected(uint256 amount, address owner);
+  event BoostedToMax(uint256 amount, address owner);
 
   struct Lock {
     uint256 amount;
@@ -165,6 +167,8 @@ contract SharesTimeLock is Ownable() {
       lockDuration: maxLockDuration,
       owner: msg.sender
     }));
+
+    emit BoostedToMax(lock.amount, msg.sender);
   }
 
   // Eject expired locks
@@ -182,6 +186,8 @@ contract SharesTimeLock is Ownable() {
       dividendsToken.burn(lock.owner, dividendShares);
 
       depositToken.safeTransfer(lock.owner, lock.amount);
+
+      emit Ejected(lock.amount, lock.owner);
     }
   }
 


### PR DESCRIPTION
Solves #10 

- [x] Eject, implemented in the `for` loop for each ejection. As a side note: why don't we implement a `ejectBatch` and an `eject` function? In this way we can emit one event for the batch including all locks ejected, lowering `LOG1` calls (and gas consumption) 
- [x] boostToMax
- [ ] distribute, is implemented in the contract `AbstractDividends` as `DividendsDistributed`
- [x] collectForWithParticipation (emitted on collectWithParticipation too)