### PR TITLE
Renaming globally

### DIFF
--- a/contracts/ERC20NonTransferableRewardsOwned.sol
+++ b/contracts/ERC20NonTransferableRewardsOwned.sol
@@ -4,12 +4,12 @@ pragma abicoder v2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/cryptography/MerkleProof.sol";
-import "./base/ERC20NonTransferableDividends.sol";
+import "./base/ERC20NonTransferableRewards.sol";
 import "./libraries/TransferHelper.sol";
 import "hardhat/console.sol";
 
 
-contract ERC20NonTransferableDividendsOwned is ERC20NonTransferableDividends, Ownable {
+contract ERC20NonTransferableRewardsOwned is ERC20NonTransferableRewards, Ownable {
   using TransferHelper for address;
 
   address public immutable token;
@@ -34,7 +34,7 @@ contract ERC20NonTransferableDividendsOwned is ERC20NonTransferableDividends, Ow
     address token_,
     string memory name_,
     string memory symbol_
-  ) ERC20NonTransferableDividends(name_, symbol_) Ownable() {
+  ) ERC20NonTransferableRewards(name_, symbol_) Ownable() {
     token = token_;
   }
 
@@ -87,12 +87,12 @@ contract ERC20NonTransferableDividendsOwned is ERC20NonTransferableDividends, Ow
       totalRedistributed += _prepareCollect(accounts[i]);
     }
 
-    _distributeDividends(totalRedistributed);
+    _distributeRewards(totalRedistributed);
   }
 
   function distribute(uint256 amount) external {
     token.safeTransferFrom(msg.sender, address(this), amount);
-    _distributeDividends(amount);
+    _distributeRewards(amount);
   }
 
 

--- a/contracts/base/AbstractRewards.sol
+++ b/contracts/base/AbstractRewards.sol
@@ -4,7 +4,7 @@ pragma solidity =0.7.6;
 import "@openzeppelin/contracts/math/SignedSafeMath.sol";
 import "../libraries/LowGasSafeMath.sol";
 import "../libraries/SafeCast.sol";
-import "../interfaces/IAbstractDividends.sol";
+import "../interfaces/IAbstractRewards.sol";
 
 /**
  * @dev Many functions in this contract were taken from this repository:
@@ -13,10 +13,10 @@ import "../interfaces/IAbstractDividends.sol";
  * https://github.com/atpar/funds-distribution-token/blob/master/EIP-DRAFT.md
  *
  * This contract has been substantially modified from the original and does not comply with ERC 2222.
- * Many functions were renamed as "dividends" rather than "funds" and the core functionality was separated
- * into this abstract contract which can be inherited by anything tracking ownership of dividend shares.
+ * Many functions were renamed as "rewards" rather than "funds" and the core functionality was separated
+ * into this abstract contract which can be inherited by anything tracking ownership of reward shares.
  */
-abstract contract AbstractDividends is IAbstractDividends {
+abstract contract AbstractRewards is IAbstractRewards {
   using LowGasSafeMath for uint256;
   using SafeCast for uint128;
   using SafeCast for uint256;
@@ -33,7 +33,7 @@ abstract contract AbstractDividends is IAbstractDividends {
 /* ========  Storage  ======== */
   uint256 public pointsPerShare;
   mapping(address => int256) internal pointsCorrection;
-  mapping(address => uint256) private withdrawnDividends;
+  mapping(address => uint256) private withdrawnRewards;
 
   constructor(
     function(address) view returns (uint256) getSharesOf_,
@@ -45,31 +45,31 @@ abstract contract AbstractDividends is IAbstractDividends {
 
 /* ========  Public View Functions  ======== */
   /**
-   * @dev Returns the total amount of dividends a given address is able to withdraw.
-   * @param account Address of a dividend recipient
-   * @return A uint256 representing the dividends `account` can withdraw
+   * @dev Returns the total amount of rewards a given address is able to withdraw.
+   * @param account Address of a reward recipient
+   * @return A uint256 representing the rewards `account` can withdraw
    */
-  function withdrawableDividendsOf(address account) public view override returns (uint256) {
-    return cumulativeDividendsOf(account).sub(withdrawnDividends[account]);
+  function withdrawableRewardsOf(address account) public view override returns (uint256) {
+    return cumulativeRewardsOf(account).sub(withdrawnRewards[account]);
   }
 
   /**
-   * @notice View the amount of dividends that an address has withdrawn.
+   * @notice View the amount of rewards that an address has withdrawn.
    * @param account The address of a token holder.
-   * @return The amount of dividends that `account` has withdrawn.
+   * @return The amount of rewards that `account` has withdrawn.
    */
-  function withdrawnDividendsOf(address account) public view override returns (uint256) {
-    return withdrawnDividends[account];
+  function withdrawnRewardsOf(address account) public view override returns (uint256) {
+    return withdrawnRewards[account];
   }
 
   /**
-   * @notice View the amount of dividends that an address has earned in total.
-   * @dev accumulativeFundsOf(account) = withdrawableDividendsOf(account) + withdrawnDividendsOf(account)
+   * @notice View the amount of rewards that an address has earned in total.
+   * @dev accumulativeFundsOf(account) = withdrawableRewardsOf(account) + withdrawnRewardsOf(account)
    * = (pointsPerShare * balanceOf(account) + pointsCorrection[account]) / POINTS_MULTIPLIER
    * @param account The address of a token holder.
-   * @return The amount of dividends that `account` has earned in total.
+   * @return The amount of rewards that `account` has earned in total.
    */
-  function cumulativeDividendsOf(address account) public view override returns (uint256) {
+  function cumulativeRewardsOf(address account) public view override returns (uint256) {
     return pointsPerShare
       .mul(getSharesOf(account))
       .toInt256()
@@ -77,19 +77,19 @@ abstract contract AbstractDividends is IAbstractDividends {
       .toUint256() / POINTS_MULTIPLIER;
   }
 
-/* ========  Dividend Utility Functions  ======== */
+/* ========  Reward Utility Functions  ======== */
 
   /** 
-   * @notice Distributes dividends to token holders.
+   * @notice Distributes rewards to token holders.
    * @dev It reverts if the total supply is 0.
    * It emits the `FundsDistributed` event if the amount to distribute is greater than 0.
-   * About undistributed dividends:
+   * About undistributed rewards:
    *   In each distribution, there is a small amount which does not get distributed,
    *   which is `(amount * POINTS_MULTIPLIER) % totalShares()`.
    *   With a well-chosen `POINTS_MULTIPLIER`, the amount of funds that are not getting
    *   distributed in a distribution can be less than 1 (base unit).
    */
-  function _distributeDividends(uint256 amount) internal {
+  function _distributeRewards(uint256 amount) internal {
     uint256 shares = getTotalShares();
     require(shares > 0, "SHARES");
 
@@ -97,22 +97,22 @@ abstract contract AbstractDividends is IAbstractDividends {
       pointsPerShare = pointsPerShare.add(
         amount.mul(POINTS_MULTIPLIER) / shares
       );
-      emit DividendsDistributed(msg.sender, amount);
+      emit RewardsDistributed(msg.sender, amount);
     }
   }
 
   /**
-   * @notice Prepares collection of owed dividends
-   * @dev It emits a `DividendsWithdrawn` event if the amount of withdrawn dividends is
+   * @notice Prepares collection of owed rewards
+   * @dev It emits a `RewardsWithdrawn` event if the amount of withdrawn rewards is
    * greater than 0.
    */
   function _prepareCollect(address account) internal returns (uint256) {
-    uint256 _withdrawableDividend = withdrawableDividendsOf(account);
-    if (_withdrawableDividend > 0) {
-      withdrawnDividends[account] = withdrawnDividends[account].add(_withdrawableDividend);
-      emit DividendsWithdrawn(account, _withdrawableDividend);
+    uint256 _withdrawableReward = withdrawableRewardsOf(account);
+    if (_withdrawableReward > 0) {
+      withdrawnRewards[account] = withdrawnRewards[account].add(_withdrawableReward);
+      emit RewardsWithdrawn(account, _withdrawableReward);
     }
-    return _withdrawableDividend;
+    return _withdrawableReward;
   }
 
   function _correctPointsForTransfer(address from, address to, uint256 shares) internal {

--- a/contracts/base/ERC20NonTransferableRewards.sol
+++ b/contracts/base/ERC20NonTransferableRewards.sol
@@ -2,21 +2,21 @@
 pragma solidity =0.7.6;
 
 import "./ERC20NonTransferable.sol";
-import "./AbstractDividends.sol";
+import "./AbstractRewards.sol";
 
 /**
-* @dev Same as the ERC20Dividends.sol but using the non transferable ERC20 base class    
+* @dev Same as the ERC20Rewards.sol but using the non transferable ERC20 base class    
 */
-contract ERC20NonTransferableDividends is ERC20NonTransferable, AbstractDividends {
+contract ERC20NonTransferableRewards is ERC20NonTransferable, AbstractRewards {
   /**
-   * @dev Wrapper for balanceOf to give AbstractDividends a function reference.
+   * @dev Wrapper for balanceOf to give AbstractRewards a function reference.
    */
   function _balanceOf(address account) internal view returns (uint256) {
     return balanceOf[account];
   }
 
   /**
-   * @dev Wrapper for totalSupply to give AbstractDividends a function reference.
+   * @dev Wrapper for totalSupply to give AbstractRewards a function reference.
    */
   function _totalSupply() internal view returns (uint256) {
     return totalSupply;
@@ -24,7 +24,7 @@ contract ERC20NonTransferableDividends is ERC20NonTransferable, AbstractDividend
 
   constructor(string memory name, string memory symbol)
     ERC20NonTransferable(name, symbol, 18)
-    AbstractDividends(_balanceOf, _totalSupply)
+    AbstractRewards(_balanceOf, _totalSupply)
   {}
 
 	/**

--- a/contracts/interfaces/IAbstractRewards.sol
+++ b/contracts/interfaces/IAbstractRewards.sol
@@ -2,41 +2,41 @@
 pragma solidity =0.7.6;
 
 
-interface IAbstractDividends {
+interface IAbstractRewards {
 	/**
-	 * @dev Returns the total amount of dividends a given address is able to withdraw.
-	 * @param account Address of a dividend recipient
-	 * @return A uint256 representing the dividends `account` can withdraw
+	 * @dev Returns the total amount of rewards a given address is able to withdraw.
+	 * @param account Address of a reward recipient
+	 * @return A uint256 representing the rewards `account` can withdraw
 	 */
-	function withdrawableDividendsOf(address account) external view returns (uint256);
+	function withdrawableRewardsOf(address account) external view returns (uint256);
 
   /**
 	 * @dev View the amount of funds that an address has withdrawn.
 	 * @param account The address of a token holder.
 	 * @return The amount of funds that `account` has withdrawn.
 	 */
-	function withdrawnDividendsOf(address account) external view returns (uint256);
+	function withdrawnRewardsOf(address account) external view returns (uint256);
 
 	/**
 	 * @dev View the amount of funds that an address has earned in total.
-	 * accumulativeFundsOf(account) = withdrawableDividendsOf(account) + withdrawnDividendsOf(account)
+	 * accumulativeFundsOf(account) = withdrawableRewardsOf(account) + withdrawnRewardsOf(account)
 	 * = (pointsPerShare * balanceOf(account) + pointsCorrection[account]) / POINTS_MULTIPLIER
 	 * @param account The address of a token holder.
 	 * @return The amount of funds that `account` has earned in total.
 	 */
-	function cumulativeDividendsOf(address account) external view returns (uint256);
+	function cumulativeRewardsOf(address account) external view returns (uint256);
 
 	/**
 	 * @dev This event emits when new funds are distributed
 	 * @param by the address of the sender who distributed funds
-	 * @param dividendsDistributed the amount of funds received for distribution
+	 * @param rewardsDistributed the amount of funds received for distribution
 	 */
-	event DividendsDistributed(address indexed by, uint256 dividendsDistributed);
+	event RewardsDistributed(address indexed by, uint256 rewardsDistributed);
 
 	/**
 	 * @dev This event emits when distributed funds are withdrawn by a token holder.
 	 * @param by the address of the receiver of funds
 	 * @param fundsWithdrawn the amount of funds that were withdrawn
 	 */
-	event DividendsWithdrawn(address indexed by, uint256 fundsWithdrawn);
+	event RewardsWithdrawn(address indexed by, uint256 fundsWithdrawn);
 }

--- a/contracts/interfaces/IERC20Rewards.sol
+++ b/contracts/interfaces/IERC20Rewards.sol
@@ -4,25 +4,25 @@ pragma solidity =0.7.6;
 import "./IERC20Metadata.sol";
 
 
-interface IERC20Dividends is IERC20Metadata {
+interface IERC20Rewards is IERC20Metadata {
 	/**
-	 * @dev Returns the total amount of dividends a given address is able to withdraw currently.
+	 * @dev Returns the total amount of rewards a given address is able to withdraw currently.
 	 * @param owner Address of FundsDistributionToken holder
 	 * @return A uint256 representing the available funds for a given account
 	 */
-	function withdrawableDividendsOf(address owner) external view returns (uint256);
+	function withdrawableRewardsOf(address owner) external view returns (uint256);
 
 	/**
 	 * @dev This event emits when new funds are distributed
 	 * @param by the address of the sender who distributed funds
-	 * @param dividendsDistributed the amount of funds received for distribution
+	 * @param rewardsDistributed the amount of funds received for distribution
 	 */
-	event DividendsDistributed(address indexed by, uint256 dividendsDistributed);
+	event RewardsDistributed(address indexed by, uint256 rewardsDistributed);
 
 	/**
 	 * @dev This event emits when distributed funds are withdrawn by a token holder.
 	 * @param by the address of the receiver of funds
 	 * @param fundsWithdrawn the amount of funds that were withdrawn
 	 */
-	event DividendsWithdrawn(address indexed by, uint256 fundsWithdrawn);
+	event RewardsWithdrawn(address indexed by, uint256 fundsWithdrawn);
 }

--- a/contracts/test/TestERC20NonTransferableDividends.sol
+++ b/contracts/test/TestERC20NonTransferableDividends.sol
@@ -2,11 +2,11 @@
 pragma solidity =0.7.6;
 pragma abicoder v2;
 
-import "../ERC20NonTransferableDividendsOwned.sol";
+import "../ERC20NonTransferableRewardsOwned.sol";
 
 
-contract TestERC20NonTransferableDividends is ERC20NonTransferableDividendsOwned {
-  constructor() ERC20NonTransferableDividendsOwned(address(0), "ERC20Dividends", "DIV") {}
+contract TestERC20NonTransferableRewards is ERC20NonTransferableRewardsOwned {
+  constructor() ERC20NonTransferableRewardsOwned(address(0), "ERC20Rewards", "DIV") {}
 
   function mint(address account, uint256 amount) external override {
     _mint(account, amount);
@@ -16,16 +16,16 @@ contract TestERC20NonTransferableDividends is ERC20NonTransferableDividendsOwned
     _burn(account, amount);
   }
 
-  function distributeDividends(uint256 amount) external {
-    _distributeDividends(amount);
+  function distributeRewards(uint256 amount) external {
+    _distributeRewards(amount);
   }
 
   function getPointsCorrection(address account) external view returns (int256) {
     return pointsCorrection[account];
   }
 
-  function getWithdrawnDividends(address account) external view returns (uint256) {
-    return withdrawnDividendsOf(account);
+  function getWithdrawnRewards(address account) external view returns (uint256) {
+    return withdrawnRewardsOf(account);
   }
 
   function prepareCollect(address account) external returns (uint256) {

--- a/tasks/deploy.ts
+++ b/tasks/deploy.ts
@@ -1,6 +1,6 @@
 import { task } from "hardhat/config";
-import { ERC20NonTransferableDividendsOwned } from "../typechain/ERC20NonTransferableDividendsOwned";
-import { ERC20NonTransferableDividendsOwned__factory } from "../typechain/factories/ERC20NonTransferableDividendsOwned__factory"
+import { ERC20NonTransferableRewardsOwned } from "../typechain/ERC20NonTransferableRewardsOwned";
+import { ERC20NonTransferableRewardsOwned__factory } from "../typechain/factories/ERC20NonTransferableRewardsOwned__factory"
 import { SharesTimeLock__factory } from "../typechain/factories/SharesTimeLock__factory";
 
 task("deploy-staking")
@@ -14,7 +14,7 @@ task("deploy-staking")
     .setAction(async(taskArgs, {ethers, network}) => {
         const signer = (await ethers.getSigners())[0];
 
-        const dToken = await (new ERC20NonTransferableDividendsOwned__factory(signer)).deploy(
+        const dToken = await (new ERC20NonTransferableRewardsOwned__factory(signer)).deploy(
             taskArgs.rewardToken,
             taskArgs.name,
             taskArgs.symbol

--- a/test/ERC20NonTransferableRewards.spec.ts
+++ b/test/ERC20NonTransferableRewards.spec.ts
@@ -1,19 +1,19 @@
 import { ethers, waffle } from 'hardhat';
 import { expect } from "chai";
-import {  TestERC20NonTransferableDividends } from '../typechain/TestERC20NonTransferableDividends';
+import {  TestERC20NonTransferableRewards } from '../typechain/TestERC20NonTransferableRewards';
 import { POINTS_MULTIPLIER, toBigNumber } from './shared/utils';
 import { BigNumber } from 'ethers';
 import { createParticipationTree, ParticipationEntry, ParticipationEntryWithLeaf } from '../utils';
 import { MerkleTree } from '../utils/MerkleTree';
 import { parseEther } from 'ethers/lib/utils';
 
-describe('ERC20NonTransferableDividendBearing', () => {
+describe('ERC20NonTransferableRewardBearing', () => {
   let [wallet, wallet1, wallet2] = waffle.provider.getWallets()
-  let erc20: TestERC20NonTransferableDividends;
+  let erc20: TestERC20NonTransferableRewards;
 
-  beforeEach('Deploy TestERC20Dividends', async () => {
-    const factory = await ethers.getContractFactory('TestERC20NonTransferableDividends')
-    erc20 = (await factory.deploy()) as TestERC20NonTransferableDividends;
+  beforeEach('Deploy TestERC20Rewards', async () => {
+    const factory = await ethers.getContractFactory('TestERC20NonTransferableRewards')
+    erc20 = (await factory.deploy()) as TestERC20NonTransferableRewards;
   })
 
   const getPointsPerShare = (amount: BigNumber, totalSupply: BigNumber) => amount.mul(POINTS_MULTIPLIER).div(totalSupply);
@@ -35,7 +35,7 @@ describe('ERC20NonTransferableDividendBearing', () => {
     it('Should decrease pointsCorrection if points distributed is >0', async () => {
       const amount = toBigNumber(10)
       await erc20.mint(wallet.address, amount)
-      await erc20.distributeDividends(toBigNumber(5))
+      await erc20.distributeRewards(toBigNumber(5))
       await erc20.mint(wallet.address, amount)
       const pointsPerShare = getPointsPerShare(toBigNumber(5), amount);
       expect(await erc20.getPointsCorrection(wallet.address)).to.eq(amount.mul(pointsPerShare).mul(-1))
@@ -61,29 +61,29 @@ describe('ERC20NonTransferableDividendBearing', () => {
         it('Should increase pointsCorrection', async () => {
           const amount = toBigNumber(5)
           await erc20.mint(wallet.address, amount)
-          await erc20.distributeDividends(amount)
+          await erc20.distributeRewards(amount)
           await erc20.burn(wallet.address, amount)
           const pointsPerShare = getPointsPerShare(amount, amount);
           expect(await erc20.getPointsCorrection(wallet.address)).to.eq(amount.mul(pointsPerShare))
         })
 
-        it('Should allow caller to withdraw dividends earned before burn', async () => {
+        it('Should allow caller to withdraw rewards earned before burn', async () => {
           const amount = toBigNumber(10)
           await erc20.mint(wallet.address, amount)
-          await erc20.distributeDividends(toBigNumber(5).add(1))
+          await erc20.distributeRewards(toBigNumber(5).add(1))
           await erc20.burn(wallet.address, amount)
-          expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(5))
+          expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(5))
         })
       })
 
       describe('When caller received tokens after disbursal', () => {
-        it('Should not allow caller to withdraw dividends disbursed before receipt of tokens', async () => {
+        it('Should not allow caller to withdraw rewards disbursed before receipt of tokens', async () => {
           const amount = toBigNumber(10)
           await erc20.mint(wallet.address, amount)
-          await erc20.distributeDividends(toBigNumber(5))
+          await erc20.distributeRewards(toBigNumber(5))
           await erc20.mint(wallet1.address, amount)
           await erc20.burn(wallet1.address, amount)
-          expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(0)
+          expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(0)
         })
       })
     })
@@ -97,36 +97,36 @@ describe('ERC20NonTransferableDividendBearing', () => {
     });
   })
 
-  describe('distributeDividends', () => {
+  describe('distributeRewards', () => {
     it('Should revert if total supply is 0', async () => {
-      await expect(erc20.distributeDividends(1)).to.be.revertedWith('SHARES')
+      await expect(erc20.distributeRewards(1)).to.be.revertedWith('SHARES')
     })
 
     it('Should increase pointsPerShare', async () => {
       await erc20.mint(wallet.address, toBigNumber(100))
-      await erc20.distributeDividends(toBigNumber(10))
+      await erc20.distributeRewards(toBigNumber(10))
       expect(await erc20.pointsPerShare()).to.eq(POINTS_MULTIPLIER.div(10))
     })
 
     it('Should do nothing if amount is 0', async () => {
       await erc20.mint(wallet.address, toBigNumber(100))
-      await erc20.distributeDividends(0)
+      await erc20.distributeRewards(0)
       expect(await erc20.pointsPerShare()).to.eq(0)
     })
   })
 
   describe('prepareCollect', () => {
-    it('Does nothing if user balance or dividends are 0', async () => {
+    it('Does nothing if user balance or rewards are 0', async () => {
       await erc20.prepareCollect(wallet.address)
-      expect(await erc20.withdrawnDividendsOf(wallet.address)).to.eq(0)
+      expect(await erc20.withdrawnRewardsOf(wallet.address)).to.eq(0)
     })
 
-    it('Updates withdrawnDividends', async () => {
+    it('Updates withdrawnRewards', async () => {
       await erc20.mint(wallet.address, toBigNumber(5));
-      await erc20.distributeDividends(toBigNumber(10));
+      await erc20.distributeRewards(toBigNumber(10));
       await erc20.prepareCollect(wallet.address)
-      expect(await erc20.withdrawnDividendsOf(wallet.address)).to.eq(toBigNumber(10))
-      expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(0)
+      expect(await erc20.withdrawnRewardsOf(wallet.address)).to.eq(toBigNumber(10))
+      expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(0)
     })
   });
 
@@ -167,17 +167,17 @@ describe('ERC20NonTransferableDividendBearing', () => {
 
       it("Claiming rewards when you have been actively participating should work", async() => {
         await erc20.mint(wallet.address, toBigNumber(5));
-        await erc20.distributeDividends(toBigNumber(10));
+        await erc20.distributeRewards(toBigNumber(10));
         
         await erc20.collectWithParticipation(merkleTree.getProof(leafs[0].leaf));
 
-        expect(await erc20.withdrawnDividendsOf(wallet.address)).to.eq(toBigNumber(10))
-        expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(0)
+        expect(await erc20.withdrawnRewardsOf(wallet.address)).to.eq(toBigNumber(10))
+        expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(0)
       });
 
       it("Claiming rewards when you have not been actively participating should fail", async() => {
         await erc20.mint(wallet1.address, toBigNumber(5));
-        await erc20.distributeDividends(toBigNumber(10));
+        await erc20.distributeRewards(toBigNumber(10));
         
         await expect(erc20.connect(wallet1).collectWithParticipation(merkleTree.getProof(leafs[1].leaf)))
           .to.be.revertedWith("collectForWithParticipation: Invalid merkle proof");
@@ -186,142 +186,142 @@ describe('ERC20NonTransferableDividendBearing', () => {
       it("Redistributing rewards should work", async() => {
         await erc20.mint(wallet1.address, toBigNumber(5));
         await erc20.mint(wallet.address, toBigNumber(5));
-        await erc20.distributeDividends(toBigNumber(10));
+        await erc20.distributeRewards(toBigNumber(10));
 
         await erc20.redistribute([wallet1.address], [merkleTree.getProof(leafs[1].leaf)]);
         
-        expect(await erc20.withdrawnDividendsOf(wallet1.address)).to.eq(toBigNumber(5));
+        expect(await erc20.withdrawnRewardsOf(wallet1.address)).to.eq(toBigNumber(5));
         // small rounding inacuracy
-        expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(parseEther("2.5").sub(1));
-        expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(parseEther("7.5").sub(1));
+        expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(parseEther("2.5").sub(1));
+        expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(parseEther("7.5").sub(1));
       });
     });
   });
 
-  describe('cumulativeDividendsOf', () => {
-    it('Should store total dividends for one user', async () => {
+  describe('cumulativeRewardsOf', () => {
+    it('Should store total rewards for one user', async () => {
       await erc20.mint(wallet.address, toBigNumber(5))
-      await erc20.distributeDividends(toBigNumber(10))
-      expect(await erc20.cumulativeDividendsOf(wallet.address)).to.eq(toBigNumber(10))
-      await erc20.distributeDividends(toBigNumber(5))
-      expect(await erc20.cumulativeDividendsOf(wallet.address)).to.eq(toBigNumber(15))
+      await erc20.distributeRewards(toBigNumber(10))
+      expect(await erc20.cumulativeRewardsOf(wallet.address)).to.eq(toBigNumber(10))
+      await erc20.distributeRewards(toBigNumber(5))
+      expect(await erc20.cumulativeRewardsOf(wallet.address)).to.eq(toBigNumber(15))
     })
 
     it('Should leave (amount*multiplier)%supply as dust', async () => {
       await erc20.mint(wallet.address, toBigNumber(5))
-      await erc20.distributeDividends(toBigNumber(10).add(1))
-      expect(await erc20.cumulativeDividendsOf(wallet.address)).to.eq(toBigNumber(10))
+      await erc20.distributeRewards(toBigNumber(10).add(1))
+      expect(await erc20.cumulativeRewardsOf(wallet.address)).to.eq(toBigNumber(10))
     })
 
-    it('Should not add dividends if no new points since caller received tokens', async () => {
+    it('Should not add rewards if no new points since caller received tokens', async () => {
       await erc20.mint(wallet.address, toBigNumber(5))
-      await erc20.distributeDividends(toBigNumber(10).add(1))
-      expect(await erc20.cumulativeDividendsOf(wallet.address)).to.eq(toBigNumber(10))
+      await erc20.distributeRewards(toBigNumber(10).add(1))
+      expect(await erc20.cumulativeRewardsOf(wallet.address)).to.eq(toBigNumber(10))
       await erc20.mint(wallet.address, toBigNumber(5))
-      expect(await erc20.cumulativeDividendsOf(wallet.address)).to.eq(toBigNumber(10))
+      expect(await erc20.cumulativeRewardsOf(wallet.address)).to.eq(toBigNumber(10))
     })
   })
 
   describe('Behavior', () => {
-    describe('When dividends are disbursed', () => {
-      it('Holders receive pro-rata shares of dividends', async () => {
+    describe('When rewards are disbursed', () => {
+      it('Holders receive pro-rata shares of rewards', async () => {
         await erc20.mint(wallet.address, toBigNumber(5))
         await erc20.mint(wallet1.address, toBigNumber(10))
         await erc20.mint(wallet2.address, toBigNumber(85))
-        await erc20.distributeDividends(toBigNumber(10).add(1))
-        expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(5, 17))
-        expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(1))
-        expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
+        await erc20.distributeRewards(toBigNumber(10).add(1))
+        expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(5, 17))
+        expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(1))
+        expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
       })
 
       // describe('When a holder transfers all shares after', () => {
-      //   it('Dividends earned previously do not change', async () => {
+      //   it('Rewards earned previously do not change', async () => {
       //     await erc20.mint(wallet.address, toBigNumber(5))
       //     await erc20.mint(wallet1.address, toBigNumber(10))
       //     await erc20.mint(wallet2.address, toBigNumber(85))
-      //     await erc20.distributeDividends(toBigNumber(10).add(1))
+      //     await erc20.distributeRewards(toBigNumber(10).add(1))
       //     await erc20.transfer(wallet.address, toBigNumber(5))
-      //     expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(5, 17))
-      //     expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(1))
-      //     expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
+      //     expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(5, 17))
+      //     expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(1))
+      //     expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
       //   })
       // })
 
       describe('When a holder burns all shares after', () => {
-        it('Dividends earned previously do not change', async () => {
+        it('Rewards earned previously do not change', async () => {
           await erc20.mint(wallet.address, toBigNumber(5))
           await erc20.mint(wallet1.address, toBigNumber(10))
           await erc20.mint(wallet2.address, toBigNumber(85))
-          await erc20.distributeDividends(toBigNumber(10).add(1))
+          await erc20.distributeRewards(toBigNumber(10).add(1))
           await erc20.burn(wallet.address, toBigNumber(5))
-          expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(5, 17))
-          expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(1))
-          expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
+          expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(5, 17))
+          expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(1))
+          expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
         })
 
-        it('Holder does not earn dividends distributed after', async () => {
+        it('Holder does not earn rewards distributed after', async () => {
           const amount = toBigNumber(5)
           await erc20.mint(wallet.address, amount)
           await erc20.mint(wallet1.address, amount)
           await erc20.mint(wallet2.address, amount)
-          await erc20.distributeDividends(toBigNumber(6).add(1))
+          await erc20.distributeRewards(toBigNumber(6).add(1))
           await erc20.burn(wallet.address, amount)
-          await erc20.distributeDividends(toBigNumber(6).add(1))
-          expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(2))
-          expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(5))
-          expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(5))
+          await erc20.distributeRewards(toBigNumber(6).add(1))
+          expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(2))
+          expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(5))
+          expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(5))
         })
       })
 
       describe('When a holder burns some shares after', () => {
-        it('Dividends earned previously do not change', async () => {
+        it('Rewards earned previously do not change', async () => {
           await erc20.mint(wallet.address, toBigNumber(5))
           await erc20.mint(wallet1.address, toBigNumber(10))
           await erc20.mint(wallet2.address, toBigNumber(85))
-          await erc20.distributeDividends(toBigNumber(10).add(1))
+          await erc20.distributeRewards(toBigNumber(10).add(1))
           await erc20.burn(wallet.address, toBigNumber(3))
-          expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(5, 17))
-          expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(1))
-          expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
+          expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(5, 17))
+          expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(1))
+          expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
         })
 
-        it('Holder earns pro-rata share of dividends distributed after', async () => {
+        it('Holder earns pro-rata share of rewards distributed after', async () => {
           const amount = toBigNumber(5)
           await erc20.mint(wallet.address, amount)
           await erc20.mint(wallet1.address, amount)
           await erc20.mint(wallet2.address, amount)
-          await erc20.distributeDividends(toBigNumber(6).add(1))
+          await erc20.distributeRewards(toBigNumber(6).add(1))
           await erc20.burn(wallet.address, toBigNumber(3))
-          await erc20.distributeDividends(toBigNumber(6).add(1))
-          expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(3))
-          expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(45, 17))
-          expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(45, 17))
+          await erc20.distributeRewards(toBigNumber(6).add(1))
+          expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(3))
+          expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(45, 17))
+          expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(45, 17))
         })
       })
 
       describe('When a holder receives some shares after', () => {
-        it('Dividends earned previously do not change', async () => {
+        it('Rewards earned previously do not change', async () => {
           await erc20.mint(wallet.address, toBigNumber(5))
           await erc20.mint(wallet1.address, toBigNumber(10))
           await erc20.mint(wallet2.address, toBigNumber(85))
-          await erc20.distributeDividends(toBigNumber(10).add(1))
+          await erc20.distributeRewards(toBigNumber(10).add(1))
           await erc20.mint(wallet.address, toBigNumber(3))
-          expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(5, 17))
-          expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(1))
-          expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
+          expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(5, 17))
+          expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(1))
+          expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(85, 17))
         })
 
-        it('Holder earns pro-rata share of dividends distributed after', async () => {
+        it('Holder earns pro-rata share of rewards distributed after', async () => {
           const amount = toBigNumber(5)
           await erc20.mint(wallet.address, amount)
           await erc20.mint(wallet1.address, amount)
           await erc20.mint(wallet2.address, amount)
-          await erc20.distributeDividends(toBigNumber(6).add(1))
+          await erc20.distributeRewards(toBigNumber(6).add(1))
           await erc20.mint(wallet.address, amount)
-          await erc20.distributeDividends(toBigNumber(20).add(1))
-          expect(await erc20.withdrawableDividendsOf(wallet.address)).to.eq(toBigNumber(12))
-          expect(await erc20.withdrawableDividendsOf(wallet1.address)).to.eq(toBigNumber(7))
-          expect(await erc20.withdrawableDividendsOf(wallet2.address)).to.eq(toBigNumber(7))
+          await erc20.distributeRewards(toBigNumber(20).add(1))
+          expect(await erc20.withdrawableRewardsOf(wallet.address)).to.eq(toBigNumber(12))
+          expect(await erc20.withdrawableRewardsOf(wallet1.address)).to.eq(toBigNumber(7))
+          expect(await erc20.withdrawableRewardsOf(wallet2.address)).to.eq(toBigNumber(7))
         })
       })
     })

--- a/test/ERC20NonTransferableRewards.spec.ts
+++ b/test/ERC20NonTransferableRewards.spec.ts
@@ -149,7 +149,7 @@ describe('ERC20NonTransferableRewardBearing', () => {
 
     const {merkleTree, leafs} = createParticipationTree(entries);
 
-    describe.only("With participation root set", async() => {
+    describe("With participation root set", async() => {
       let root:string;
       beforeEach(async() => {
         root = merkleTree.getRoot();


### PR DESCRIPTION
Trivial PR, solves #3.

All `dividends` are now `rewards` ! 

- [x] It compiles!
- [x] Tests passes
