### PR TITLE
Adds test for `eject` and `setMinLockAmount`

### DIFF
--- a/contracts/SharesTimeLock.sol
+++ b/contracts/SharesTimeLock.sol
@@ -172,10 +172,11 @@ contract SharesTimeLock is Ownable() {
 
   // Eject expired locks
   function eject(uint256[] memory lockIds) external {
+    
     for(uint256 i = 0; i < lockIds.length; i ++) {
       Lock memory lock = locks[lockIds[i]];
       //skip if lock not expired or locked amount is zero
-      if(lock.lockedAt + lock.lockDuration < block.timestamp || lock.amount == 0) {
+      if(lock.lockedAt + lock.lockDuration > block.timestamp || lock.amount == 0) {
         continue;
       }
 


### PR DESCRIPTION
Solves #7.

The code had a bug in `SharesTimeLock.sol`. We were checking if a lock was not expired by checking if `lock.lockedAt + lock.lockDuration < block.timestamp`. This PR also adds tests for `setMinLockAmount`. 

`SharesTimeLock.sol` is now fully covered! yay!